### PR TITLE
Better documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bauth.json
 node_modules
 package-lock.json
 babotdata.json
+Data/

--- a/README.md
+++ b/README.md
@@ -1,29 +1,38 @@
 # babot
-Admin bot for glorious trumpet land<br/>
-BABA IS ADMIN, <br/>
-HANK IS PROGRAMER, <br/>
-ADAM IS PROGRAMER, <br/>
-SAMI IS PROGRAMER, <br/>
-SERVER IS SERVER, <br/>
-JOKE IS OLD, <br/>
-<br/>
-other usefull info <br/>
-dependencies <br/>
-~discord.js : npm install discord.js <br/>
-~forever : npm install forever -g <br/>
-~images : npm install images <br/>
-~node-fetch : npm install node-fetch<br/>
-~jimp : npm install jimp<br>
-to start <br/>
-~forever start babot.js <br/>
-~setting up babotdata.json
-{"token":bot token as string,"pass":response for password command as string,"adminid":admin id as string,"logchn":log chanel id as string,"temp":temp file location as string,"datalocation":location of data unpacked from FrogHolidays.zip as string,"emoji":server ban hammer emoji}<br/>
-<br/>
-commands for admins:<br/>
-!setvote <msg ID> : creates a vote with reactions on the message<br/>
-!bdelete <msg ID> : sends message to the deleted channel and removes the original<br/>
+Admin bot for glorious trumpet land  
+BABA IS ADMIN,   
+HANK IS PROGRAMER,   
+ADAM IS PROGRAMER,   
+SAMI IS PROGRAMER,
+SHANE IS PROGRAMMER,     
+SERVER IS SERVER,   
+JOKE IS OLD.  
+  
+## dependencies
+node version 16.9.0  
+dependencies included in package.json - just use
+`npm install`
+
+## running
+`forever start babot.js`
+
+## configuration
+~setting up babotdata.json:  
+{"token":bot token as string,  
+"pass":response for password command as string,  
+"adminid":admin id as string,  
+"logchn":log chanel id as string,  
+"temp":temp file location as string,  
+"datalocation":location of data unpacked from FrogHolidays.zip as string,  
+"emoji":server ban hammer emoji}  
+  
+## admin commands
+!setvote <msg ID> : creates a vote with reactions on the message  
+!bdelete <msg ID> : sends message to the deleted channel and removes the original  
 !political <msg ID> : sends message to the politics channel<br>
-!banhammer <msg ID> : baba adds an emoji from the babotdata.json file<br/>
-!grole <role name> <msg ID> : creates or adds people who react to message to role<br/>
-!bsetgame <optional activity type> <activity> : sets the game for baba <br/>
+!banhammer <msg ID> : baba adds an emoji from the babotdata.json file  
+!grole <role name> <msg ID> : creates or adds people who react to message to role  
+!bsetgame <optional activity type> <activity> : sets the game for baba
+
+## user commands
 to get user commands type !baba help (note only command  is !baba passwords at the moment)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@ SAMI IS PROGRAMER,
 SHANE IS PROGRAMMER,     
 SERVER IS SERVER,   
 JOKE IS OLD.  
-  
-## dependencies
-node version 16.9.0  
-dependencies included in package.json - just use
-`npm install`
-
-## running
-`forever start babot.js`
 
 ## configuration
 ~setting up babotdata.json:  
@@ -25,6 +17,14 @@ dependencies included in package.json - just use
 "temp":temp file location as string,  
 "datalocation":location of data unpacked from FrogHolidays.zip as string,  
 "emoji":server ban hammer emoji}  
+
+## dependencies
+node version 16.9.0  
+dependencies included in package.json - just use
+`npm install`
+
+## running
+`forever start babot.js`
   
 ## admin commands
 !setvote <msg ID> : creates a vote with reactions on the message  

--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ node version 16.9.0
 dependencies included in package.json - just use
 `npm install`
 
+## installing from scratch
+A linux system is recommended. Production uses WSL1 on Win10.  
+This guide installs nvm (Node Version Manager), node, and forever.
+
+- `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash`
+- reload terminal or `source ~/.bashrc` (on bash)
+- `nvm install 16.9.0`
+- `npm install forever -g`
+- `git clone https://github.com/Aconka/babot.git`
+- `cd babot`
+- `npm install`
+- configure babotdata.json
+- `forever start babot.js`
+
 ## running
 `node babot.js`  
 or  

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ dependencies included in package.json - just use
 `npm install`
 
 ## running
+`node babot.js`  
+or  
 `forever start babot.js`
+(requires forever: `npm install forever -g`)
   
 # Use
 

--- a/README.md
+++ b/README.md
@@ -8,15 +8,25 @@ SHANE IS PROGRAMMER,
 SERVER IS SERVER,   
 JOKE IS OLD.  
 
+# Setup
+
+## start
+- extract Data.zip (in place, creating `baba/Data/`)
+- create babotdata.json (from template: `cp babotdata.template.json babotdata.json`)
+    - see next section for configuration
+
 ## configuration
 ~setting up babotdata.json:  
-{"token":bot token as string,  
-"pass":response for password command as string,  
-"adminid":admin id as string,  
-"logchn":log chanel id as string,  
-"temp":temp file location as string,  
-"datalocation":location of data unpacked from FrogHolidays.zip as string,  
-"emoji":server ban hammer emoji}  
+{"token": bot token as string,  
+"pass": response for password command as string,  
+"datalocation": location of data unpacked from FrogHolidays.zip as string,  
+"adminid": admin role ID as string,  
+"logchn": log channel ID as string,  
+"politicschan": politics channel ID as string,  
+"holidaychan": leave as "0" - will be auto-filled,  
+"holidayval": leave as "null" - will be auto-filled,
+"temp": temp file location as string,  
+"emoji":server ban hammer emoji ID as string}  
 
 ## dependencies
 node version 16.9.0  
@@ -26,6 +36,8 @@ dependencies included in package.json - just use
 ## running
 `forever start babot.js`
   
+# Use
+
 ## admin commands
 !setvote <msg ID> : creates a vote with reactions on the message  
 !bdelete <msg ID> : sends message to the deleted channel and removes the original  

--- a/babotdata.template.json
+++ b/babotdata.template.json
@@ -1,6 +1,6 @@
 {
     "token":"CHANGEME",
-    "pass":"CHANGEME",
+    "pass":"server passwords listed here",
     "datalocation":"./Data/",
     "adminid":"",
     "logchan":"",

--- a/babotdata.template.json
+++ b/babotdata.template.json
@@ -1,0 +1,12 @@
+{
+    "token":"CHANGEME",
+    "pass":"CHANGEME",
+    "datalocation":"./Data/",
+    "adminid":"",
+    "logchan":"",
+    "politicschan":"",
+    "holidaychan":"0",
+    "holidayval":"null",
+    "temp":"./",
+    "emoji":""
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "admin bot for glorious trumpet land",
   "main": "babot.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Testing is for nerds\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "homepage": "https://github.com/Aconka/babot#readme",
   "dependencies": {
     "discord.js": "^13.1.0",
-    "forever": "^4.0.3",
     "fs": "^0.0.1-security",
     "images": "^3.2.3",
     "jimp": "^0.16.1",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "babot",
+  "version": "0.0.0",
+  "description": "admin bot for glorious trumpet land",
+  "main": "babot.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Aconka/babot.git"
+  },
+  "author": "me",
+  "license": "WTFPL",
+  "bugs": {
+    "url": "https://github.com/Aconka/babot/issues"
+  },
+  "homepage": "https://github.com/Aconka/babot#readme",
+  "dependencies": {
+    "discord.js": "^13.1.0",
+    "forever": "^4.0.3",
+    "fs": "^0.0.1-security",
+    "images": "^3.2.3",
+    "jimp": "^0.16.1",
+    "node-fetch": "^2.6.2"
+  }
+}


### PR DESCRIPTION
Reduce required goats to sacrifice to one (from two).

- improve README
  - document `babotdata.json`
  - template for babotdata: `babotdata.template.json`
- provide automatic installation of dependencies (`package.json`)
